### PR TITLE
Wrap it in a closure

### DIFF
--- a/src/compiler.rs
+++ b/src/compiler.rs
@@ -201,13 +201,11 @@ impl<'a> Compiler<'a> {
 
     fn get_rule(&self, ttype: TokenType) -> ParseRule {
         match ttype {
-            /*
             TokenType::LeftParen => ParseRule {
-                prefix: Some(Compiler::grouping),
+                prefix: Some(|c| c.grouping()),
                 infix: None,
                 precedence: Precedence::None,
             },
-            */
             _ => ParseRule {
                 prefix: None,
                 infix: None,


### PR DESCRIPTION
So the reason it didn't work was because the path of `grouping` method is `Compiler::<'q>::grouping::<'r>(&'r mut Compiler<'q>)` which has a function signature `for<'r> fn(&'r mut Compiler<'q>)`, because the `'q` lifetime should be known to instantiate type `Compiler::<'q>` to when use it to resolve the `grouping` method, while we need an `fn` with two lifetime parameters `<'r, 'c>`, i. e. `for<'r, 'c> fn(&'r mut Compiler<'c>)`.

Anyway stateless closures can be used as `fn`s, so that was an easy fix.